### PR TITLE
Revert "Add the guide release date"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,6 @@
 :projectid: cors
 :page-layout: guide
 :page-duration: 15 minutes
-:page-date: 2017-10-12
 :page-description: Learn how to enable CORS in Open Liberty
 :page-tags: ['CORS']
 :page-permalink: /guides/{projectid}


### PR DESCRIPTION
Reverts OpenLiberty/guide-cors#5

`page-date` is causing Jekyll build to break.  Another Asciidoctor attribute will be needed to replace `page-date`.  Until we have the new attribute, revert the introduction of `page-date`.