### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@
 :page-permalink: /guides/{projectid}
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master/
 :source-highlighter: prettify
-= Enabling Cross-Origin Resource Sharing (CORS) in Open Liberty
+= Enabling Cross-Origin Resource Sharing (CORS)
 
 [.hidden]
 NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].


### PR DESCRIPTION
Per agreement with Laura and Alasdair we are removing Liberty from guide titles.  It's not necessary to include and allows titles to be more concise.