### PR TITLE
Merge staging to prod - Cloud hosted adjustments (#79)

### DIFF
--- a/.github/workflows/triggerConversion.yml
+++ b/.github/workflows/triggerConversion.yml
@@ -1,0 +1,31 @@
+name: Rebuild cloud-hosted guide
+
+# Controls when the action will run. Triggers the workflow on push
+# events but only for the main branch
+on:
+  push:
+    branches:
+      - 'prod'
+      - 'staging'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "post"
+  post:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    # Uses the secrets from the organisation for credentials
+    - uses: actions/checkout@v2
+
+    - name: Invoke workflow in another repo with inputs
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: GuideConverter
+        repo: OpenLiberty/cloud-hosted-guides
+        token: ${{ secrets.GUIDECONVERSIONTOOL_PASSWORD }}
+        inputs: '{ "branch": "${{ github.ref }}", "guide_name": "${{ github.event.repository.name }}" }'
+        ref: "refs/heads/prod"

--- a/README.adoc
+++ b/README.adoc
@@ -88,6 +88,13 @@ include::{common-includes}/gitclone.adoc[]
 
 == Enabling CORS
 Navigate to the `start` directory to begin.
+// cloud hosted instructions
+ifdef::cloud-hosted[]
+```
+cd /home/project/guide-cors/start
+```
+{: codeblock}
+endif::[]
 
 [role='command']
 include::{common-includes}/devmode-lmp33-start.adoc[]
@@ -119,7 +126,7 @@ include::finish/src/main/liberty/config/server.xml[]
 
 The CORS configuration contains the following attributes:
 
-[options="header"]
+[cols="1, 2", options="header"]
 |===
 | *Configuration Attribute* | *Value*
 |[hotspot=16 file=0]`domain` | The endpoint to be configured for CORS requests. The value is set to `/configurations/simple`.
@@ -134,7 +141,8 @@ tested with a simple CORS request.
 
 The Open Liberty server was started in development mode at the beginning of the guide and all the changes were automatically picked up.
 
-Now, test the simple CORS configuration that you added. Add the [hotspot=testSimpleCorsRequest file=1]`testSimpleCorsRequest` method to the `CorsIT` class.
+Now, test the simple CORS configuration that you added. 
+Add the [hotspot=testSimpleCorsRequest file=1]`testSimpleCorsRequest` method to the `CorsIT` class.
 
 [role="code_command hotspot file=1", subs="quotes"]
 ----
@@ -152,7 +160,7 @@ The [hotspot=testSimpleCorsRequest file=1]`testSimpleCorsRequest` test simulates
 
 The request is a [hotspot=get file=1]`GET` HTTP request with the following header:
 
-[options="header"]
+[cols="1, 2", options="header"]
 |===
 | *Request Header* | *Request Value*
 | Origin | The value is set to `openliberty.io`. Indicates that the request originates from `openliberty.io`.
@@ -160,7 +168,7 @@ The request is a [hotspot=get file=1]`GET` HTTP request with the following heade
 
 Expect the following response headers and values if the simple CORS request is successful, and the server is correctly configured:
 
-[options="header"]
+[cols="1, 2", options="header"]
 |===
 | *Response Header* | *Response Value*
 | Access-Control-Allow-Origin | The expected value is `openliberty.io`. Indicates whether a resource can be shared based on the returning value of the Origin request header `openliberty.io`.
@@ -168,10 +176,11 @@ Expect the following response headers and values if the simple CORS request is s
 | Access-Control-Expose-Headers |  The expected value is `MyHeader`. Indicates that the header `MyHeader` is safe to expose.
 |===
 
-Since you started Open Liberty in development mode at the start of the guide, press the `enter/return` key to run the tests.
+Because you started Open Liberty in dev mode, you can run the tests by pressing the `enter/return` key from the command-line session where you started dev mode.
 
-If the [hotspot=testSimpleCorsRequest file=1]`testSimpleCorsRequest` test passes, the response headers with their values from the endpoint are printed. The
-`/configurations/simple` endpoint now accepts simple CORS requests.
+If the [hotspot=testSimpleCorsRequest file=1]`testSimpleCorsRequest` test passes, 
+the response headers with their values from the endpoint are printed. 
+The `/configurations/simple` endpoint now accepts simple CORS requests.
 
 Response headers with their values from the endpoint:
 [role='no_copy']
@@ -215,7 +224,7 @@ Add another CORS configuration in the `server.xml` file:
 
 The preflight CORS configuration has different values than the simple CORS configuration.
 
-[options="header"]
+[cols="1, 2", options="header"]
 |===
 | *Configuration Attribute* | *Value*
 | [hotspot=24 file=0]`domain`|The value is set to `/configurations/preflight` because the `domain` is a different endpoint.
@@ -240,11 +249,13 @@ Add another test to the [hotspot file=1]`CorsIT.java` file to test the preflight
 `src/test/java/it/io/openliberty/guides/cors/CorsIT.java`
 ----
 
-The [hotspot=testPreflightCorsRequest file=1]`testPreflightCorsRequest` test simulates a client sending a preflight CORS request. It first sends the request to the `/configurations/preflight` endpoint, and then it checks for a valid response and expected headers. Lastly, it prints the response headers for you to inspect.
+The [hotspot=testPreflightCorsRequest file=1]`testPreflightCorsRequest` test simulates a client sending a preflight CORS request. 
+It first sends the request to the `/configurations/preflight` endpoint, and then it checks for a valid response and expected headers. 
+Lastly, it prints the response headers for you to inspect.
 
 The request is an [hotspot=options file=1]`OPTIONS` HTTP request with the following headers:
 
-[options="header"]
+[cols="1, 2", options="header"]
 |===
 | *Request Header* | *Request Value*
 | Origin | The value is set to `anywebsiteyoulike.com`. Indicates that the request originates from `anywebsiteyoulike.com`.
@@ -254,7 +265,7 @@ The request is an [hotspot=options file=1]`OPTIONS` HTTP request with the follow
 
 Expect the following response headers and values if the preflight CORS request is successful, and the server is correctly configured:
 
-[options="header"]
+[cols="1, 2", options="header"]
 |===
 | *Response Header* | *Response Value*
 | Access-Control-Max-Age | The expected value is `10`. Indicates that the preflight request can be cached within `10` seconds.
@@ -268,7 +279,7 @@ The `Access-Control-Allow-Origin` header has a value of `anywebsiteyoulike.com`
 because the server is configured to allow all origins, and the request came with an origin of
 `anywebsiteyoulike.com`.
 
-Since you started Open Liberty in development mode at the start of the guide, press the `enter/return` key to run the tests.
+Because you started Open Liberty in dev mode, you can run the tests by pressing the `enter/return` key from the command-line session where you started dev mode.
 
 If the [hotspot=testPreflightCorsRequest file=1]`testPreflightCorsRequest` test passes, the response headers with their values from the endpoint are printed.
 The `/configurations/preflight` endpoint now allows preflight CORS requests.
@@ -301,8 +312,7 @@ include::{common-includes}/devmode-quit.adoc[]
 
 == Great work! You're done!
 
-You enabled CORS support in Open Liberty. You added two different
-CORS configurations to allow two kinds of CORS requests in the `server.xml` file.
+You enabled CORS support in Open Liberty. You added two different CORS configurations to allow two kinds of CORS requests in the `server.xml` file.
 
 
 include::{common-includes}/attribution.adoc[subs="attributes"]


### PR DESCRIPTION
* update README.adoc

* Create triggerConversion.yml

* Escape example URLs

* Update README.adoc

* Fix exposed attributes on cloud

* Revert "Fix exposed attributes on cloud"

This reverts commit b53dc742afc1b266e7decc449918dc08d03b32f6.

* Revert "Update README.adoc"

This reverts commit b0ed003b86ec9441798d4d091799c2b17a3c2f56.

* Revert "Escape example URLs"

This reverts commit 3e59dcecbae94052e2c5b68b9ff36d825605723d.

* Re-fix exposed attributes

* Update README.adoc

* Revert "Update README.adoc"

This reverts commit 47d0d3b7d602a6f729d1c79c3be4613fce0bd570.

* Revert "Re-fix exposed attributes"

This reverts commit b0a10177cc0a610550c3988ab06e0a93f5d639e5.

* Escape example URLs

* Revert "Escape example URLs"

This reverts commit a92e96745a9d839af924b364253d0e6f53732cc9.

* Fix table display on cloud

* Update README.adoc

* Update README.adoc

* Update README.adoc

* Update README.adoc

* Update README.adoc

* Update README.adoc

Co-authored-by: Rutav Shah <rutav.shah@ibm.com>
Co-authored-by: Gilbert Kwan <gkwan@ca.ibm.com>
Co-authored-by: David Yao <David.Yao@ibm.com>