### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -55,23 +55,23 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <default.http.port>${liberty.var.default.http.port}</default.http.port>
-                        <default.https.port>${liberty.var.default.https.port}</default.https.port>
+                        <http.port>${liberty.var.http.port}</http.port>
+                        <https.port>${liberty.var.https.port}</https.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -5,10 +5,10 @@
     <feature>jsonb-3.0</feature>
 </featureManager>
 
-<variable name="default.http.port" defaultValue="9080"/>
-<variable name="default.https.port" defaultValue="9443"/>
+<variable name="http.port" defaultValue="9080"/>
+<variable name="https.port" defaultValue="9443"/>
 
-<httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}"
+<httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}"
     id="defaultHttpEndpoint"/>
 
 <webApplication location="guide-cors.war" contextRoot="/"/>

--- a/finish/src/main/webapp/index.html
+++ b/finish/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
         </ul>

--- a/finish/src/test/java/it/io/openliberty/guides/cors/CorsIT.java
+++ b/finish/src/test/java/it/io/openliberty/guides/cors/CorsIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 public class CorsIT {
 
-    String port = System.getProperty("default.http.port");
+    String port = System.getProperty("http.port");
     String pathToHost = "http://localhost:" + port + "/";
 
     @BeforeEach

--- a/finish/src/test/java/it/io/openliberty/guides/cors/HttpUtils.java
+++ b/finish/src/test/java/it/io/openliberty/guides/cors/HttpUtils.java
@@ -20,13 +20,14 @@ import java.util.Map.Entry;
 
 public class HttpUtils {
 
-    public static HttpURLConnection sendRequest(String path, String methods, Map<String, String> requestHeaders)
-        throws IOException {
-    	return getHttpConnection(new URL(path), methods, requestHeaders);
+    public static HttpURLConnection sendRequest(String path, String methods,
+                  Map<String, String> requestHeaders) throws IOException {
+        return getHttpConnection(new URL(path), methods, requestHeaders);
     }
 
-    public static HttpURLConnection getHttpConnection(URL targetURL, String httpRequestMethod,
-        Map<String, String> headers) throws IOException {
+    public static HttpURLConnection getHttpConnection(URL targetURL,
+                  String httpRequestMethod, Map<String, String> headers)
+                  throws IOException {
         HttpURLConnection connection = (HttpURLConnection) targetURL.openConnection();
         Iterator<Entry<String, String>> entries = headers.entrySet().iterator();
         while (entries.hasNext()) {

--- a/finish/src/test/java/it/io/openliberty/guides/cors/HttpUtils.java
+++ b/finish/src/test/java/it/io/openliberty/guides/cors/HttpUtils.java
@@ -1,15 +1,14 @@
-// tag::comment[]
+// tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-// end::comment[]
+// end::copyright[]
 package it.io.openliberty.guides.cors;
 
 import java.io.IOException;

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -55,23 +55,23 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <default.http.port>${liberty.var.default.http.port}</default.http.port>
-                        <default.https.port>${liberty.var.default.https.port}</default.https.port>
+                        <http.port>${liberty.var.http.port}</http.port>
+                        <https.port>${liberty.var.https.port}</https.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -5,10 +5,10 @@
     <feature>jsonb-3.0</feature>
 </featureManager>
 
-<variable name="default.http.port" defaultValue="9080"/>
-<variable name="default.https.port" defaultValue="9443"/>
+<variable name="http.port" defaultValue="9080"/>
+<variable name="https.port" defaultValue="9443"/>
 
-<httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}"
+<httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}"
     id="defaultHttpEndpoint"/>
 
 <webApplication location="guide-cors.war" contextRoot="/"/>

--- a/start/src/main/webapp/index.html
+++ b/start/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
         </ul>

--- a/start/src/test/java/it/io/openliberty/guides/cors/CorsIT.java
+++ b/start/src/test/java/it/io/openliberty/guides/cors/CorsIT.java
@@ -1,6 +1,6 @@
 // tag::comment[]
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class CorsIT {
 
-    String port = System.getProperty("default.http.port");
+    String port = System.getProperty("http.port");
     String pathToHost = "http://localhost:" + port + "/";
 
     @BeforeEach

--- a/start/src/test/java/it/io/openliberty/guides/cors/CorsIT.java
+++ b/start/src/test/java/it/io/openliberty/guides/cors/CorsIT.java
@@ -1,4 +1,4 @@
-// tag::comment[]
+// tag::copyright[]
 /*******************************************************************************
  * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
@@ -9,7 +9,7 @@
  * Contributors:
  *     IBM Corporation - Initial implementation
  *******************************************************************************/
-// end::comment[]
+// end::copyright[]
 package it.io.openliberty.guides.cors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +43,8 @@ public class CorsIT {
         });
     }
 
-    public static void printResponseHeaders(HttpURLConnection connection, String label) {
+    public static void printResponseHeaders(HttpURLConnection connection,
+                           String label) {
         System.out.println("--- " + label + " ---");
         Map<String, java.util.List<String>> map = connection.getHeaderFields();
         for (Entry<String, java.util.List<String>> entry : map.entrySet()) {

--- a/start/src/test/java/it/io/openliberty/guides/cors/CorsIT.java
+++ b/start/src/test/java/it/io/openliberty/guides/cors/CorsIT.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package it.io.openliberty.guides.cors;

--- a/start/src/test/java/it/io/openliberty/guides/cors/HttpUtils.java
+++ b/start/src/test/java/it/io/openliberty/guides/cors/HttpUtils.java
@@ -20,13 +20,14 @@ import java.util.Map.Entry;
 
 public class HttpUtils {
 
-    public static HttpURLConnection sendRequest(String path, String methods, Map<String, String> requestHeaders)
-        throws IOException {
-    	return getHttpConnection(new URL(path), methods, requestHeaders);
+    public static HttpURLConnection sendRequest(String path, String methods,
+                  Map<String, String> requestHeaders) throws IOException {
+        return getHttpConnection(new URL(path), methods, requestHeaders);
     }
 
-    public static HttpURLConnection getHttpConnection(URL targetURL, String httpRequestMethod,
-        Map<String, String> headers) throws IOException {
+    public static HttpURLConnection getHttpConnection(URL targetURL,
+                  String httpRequestMethod, Map<String, String> headers)
+                  throws IOException {
         HttpURLConnection connection = (HttpURLConnection) targetURL.openConnection();
         Iterator<Entry<String, String>> entries = headers.entrySet().iterator();
         while (entries.hasNext()) {

--- a/start/src/test/java/it/io/openliberty/guides/cors/HttpUtils.java
+++ b/start/src/test/java/it/io/openliberty/guides/cors/HttpUtils.java
@@ -1,15 +1,14 @@
-// tag::comment[]
+// tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-// end::comment[]
+// end::copyright[]
 package it.io.openliberty.guides.cors;
 
 import java.io.IOException;


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

